### PR TITLE
Add Ci and drop .vscode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*.rs]
+[*.rs]
+indent_style = tab
+indent_size  = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install dependancies
-        run: apt install flatbuffers
+        run: |
+          sudo apt install flatbuffers
+          which flatc
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -32,7 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install dependancies
-        run: apt install flatbuffers
+        run: |
+          sudo apt install flatbuffers
+          which flatc
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -54,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install dependancies
-        run: apt install flatbuffers
+        run: |
+          sudo apt install flatbuffers
+          which flatc
       - name: Checkout sources
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: install dependancies
         run: |
-          sudo apt install flatbuffers
+          sudo apt install -y flatbuffers-compiler
           which flatc
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: install dependancies
         run: |
-          sudo apt install flatbuffers
+          sudo apt install -y flatbuffers-compiler
           which flatc
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: install dependancies
         run: |
-          sudo apt install flatbuffers
+          sudo apt install -y flatbuffers-compiler
           which flatc
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,77 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: install dependancies
+        run: apt install flatbuffers
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -29,6 +31,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - name: install dependancies
+        run: apt install flatbuffers
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -49,6 +53,8 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
+      - name: install dependancies
+        run: apt install flatbuffers
       - name: Checkout sources
         uses: actions/checkout@v2
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": true
-}

--- a/src/fusion/node.rs
+++ b/src/fusion/node.rs
@@ -22,7 +22,7 @@ impl<'a> Node<'a> {
 		object: &str,
 		method: &str,
 		data: &[u8],
-		callback: messenger::RawCallback
+		callback: messenger::RawCallback,
 	) -> Result<()> {
 		self.messenger
 			.execute_remote_method(self.path, method, data, callback)


### PR DESCRIPTION
all modern editors have support for .editorconfigs via plugins or natively. It does not make sense to have only a .vscode which is editor specific. this also adds ci that is currently failing since the upstream code is broken